### PR TITLE
Update

### DIFF
--- a/app/chapter_splitter_sub.py
+++ b/app/chapter_splitter_sub.py
@@ -225,7 +225,7 @@ def consume_callback(ch, method, properties, body):
                     sql = "SELECT sender FROM email_contents WHERE id = %s"
                     params = (email_content_id)
                     email_sql = postgre.selectSQL(sql, params)
-                    logger.info(" [x] Email SQL: ", email_sql)
+                    logger.info(" [x] Email SQL: ", email_sql[0])
                     if not email_sql:
                         logger.error(
                             f" [!] Không tìm thấy email_content_id: {email_content_id}")


### PR DESCRIPTION
This pull request introduces improvements to logging and chapter extraction logic in the codebase, focusing on better handling of Vietnamese documents and enhancing the accuracy of chapter detection. The most important changes include refining the chapter pattern to support additional formats, adding support for bold markdown headings, and improving logging clarity.

### Logging Improvements:
* Updated the logging statement in `consume_callback` to display the first element of the `email_sql` result, ensuring clearer log output. (`app/chapter_splitter_sub.py`, [app/chapter_splitter_sub.pyL228-R228](diffhunk://#diff-ce1381f2ac21a68f327cf316efafc2b4ed6762fdcd78a84ef1072116459bf980L228-R228))

### Chapter Extraction Enhancements:
* Refined the chapter pattern in `extract_chapter_smart` to support uppercase Vietnamese chapter titles (e.g., "CHƯƠNG") and added a new regex pattern for bold markdown headings. (`app/utils/extract_by_chapter_md.py`, [app/utils/extract_by_chapter_md.pyR191-R202](diffhunk://#diff-23c3c4fcd0cd835fafb017af572b58ab652182856819cc70c45e54de5d82c0a4R191-R202))
* Introduced logic to detect bold markdown headings, extract chapter details from them, and assign higher confidence to these headings during chapter detection. (`app/utils/extract_by_chapter_md.py`, [app/utils/extract_by_chapter_md.pyR211-R241](diffhunk://#diff-23c3c4fcd0cd835fafb017af572b58ab652182856819cc70c45e54de5d82c0a4R211-R241))
* Improved chapter pattern matching for lines without markdown headings by expanding support for uppercase chapter titles. (`app/utils/extract_by_chapter_md.py`, [app/utils/extract_by_chapter_md.pyL236-R278](diffhunk://#diff-23c3c4fcd0cd835fafb017af572b58ab652182856819cc70c45e54de5d82c0a4L236-R278))
* Standardized variable usage for chapter number and title extraction across different chapter detection methods. (`app/utils/extract_by_chapter_md.py`, [[1]](diffhunk://#diff-23c3c4fcd0cd835fafb017af572b58ab652182856819cc70c45e54de5d82c0a4L217-R253) [[2]](diffhunk://#diff-23c3c4fcd0cd835fafb017af572b58ab652182856819cc70c45e54de5d82c0a4L253-R288) [[3]](diffhunk://#diff-23c3c4fcd0cd835fafb017af572b58ab652182856819cc70c45e54de5d82c0a4L284-R319)