### PR TITLE
Add attachment_paths to email payload and format SQL history insertion

### DIFF
--- a/app/chapter_splitter_sub.py
+++ b/app/chapter_splitter_sub.py
@@ -246,6 +246,7 @@ def consume_callback(ch, method, properties, body):
                         "subject": f"Kết quả phân tích hồ sơ ({email_sql[0]["hs_id"]})",
                         "body": "Kính gửi anh chị,\nHiện tại hệ thống không thể xử lý hồ sơ mời thầu này.",
                         "recipient": email_sql[0]["sender"],
+                        "attachment_paths": []
                     }
 
                     rabbit_mq.publish(
@@ -310,9 +311,11 @@ def consume_callback(ch, method, properties, body):
         files_object = [
             {k: v for k, v in file.items() if k != "file_type"} for file in files_object
         ]
-        inserted_step_chapter_splitter = postgre.insertHistorySQL(hs_id=hs_id, step="CHAPTER_SPLITER")
+        inserted_step_chapter_splitter = postgre.insertHistorySQL(
+            hs_id=hs_id, step="CHAPTER_SPLITER")
         if not inserted_step_chapter_splitter:
-            print("Không insert được trạng thái 'CHAPTER_SPLITER' vào history với hs_id: %s", hs_id)
+            print(
+                "Không insert được trạng thái 'CHAPTER_SPLITER' vào history với hs_id: %s", hs_id)
         if files_object:
             next_queue = RABBIT_MQ_MARKDOWN_QUEUE
             next_message = {"id": hs_id, "files": files_object}


### PR DESCRIPTION
This pull request makes minor improvements to the `consume_callback` function in the `app/chapter_splitter_sub.py` file, focusing on code formatting and functionality enhancements. The most important changes include adding an empty `attachment_paths` field to the email payload and improving code readability by reformatting long lines.

### Functionality enhancement:
* Added an empty `attachment_paths` field to the email payload dictionary to ensure compatibility with potential future requirements for email attachments. (`[app/chapter_splitter_sub.pyR249](diffhunk://#diff-ce1381f2ac21a68f327cf316efafc2b4ed6762fdcd78a84ef1072116459bf980R249)`)

### Code readability improvements:
* Reformatted the `postgre.insertHistorySQL` method call and a `print` statement to improve readability by breaking long lines into multiple lines. (`[app/chapter_splitter_sub.pyL313-R318](diffhunk://#diff-ce1381f2ac21a68f327cf316efafc2b4ed6762fdcd78a84ef1072116459bf980L313-R318)`)