### PR TITLE
Remove easyocr version 1.7.2 and update opencv-python-headless to 4.1…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -62,7 +62,6 @@ dill==0.3.8
 distro==1.9.0
 dnspython==2.7.0
 docx2md==1.0.3
-easyocr==1.7.2
 ecdsa==0.19.0
 einops==0.2.0
 email_validator==2.2.0
@@ -194,7 +193,7 @@ olefile==0.47
 onnxruntime==1.19.2
 openai==1.55.3
 opencv-contrib-python==4.11.0.86
-opencv-python-headless==4.10.0.84
+opencv-python-headless==4.11.0.86
 openpyxl==3.1.5
 orjson==3.10.12
 outcome==1.3.0.post0


### PR DESCRIPTION
…1.0.86 in requirements.txt